### PR TITLE
Update trailing commas setting

### DIFF
--- a/prettier-config/index.js
+++ b/prettier-config/index.js
@@ -1,6 +1,6 @@
 module.exports =  {
     semi:  true,
-    trailingComma:  'all',
+    trailingComma:  'es5',
     singleQuote:  true,
     printWidth:  120,
     tabWidth:  4,


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Do not use 'all' setting for trailing commas, use 'es5' instead.